### PR TITLE
tell tsc where to find the types

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Find multiple free ports on localhost",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "prepare": "tsc && babel --extensions '.ts' index.ts tests.ts --out-dir . --source-maps",
     "watch": "concurrently 'ava --watch' 'babel --watch --extensions .ts index.ts tests.ts --out-dir .'",


### PR DESCRIPTION
My tsc config is slight more strict then this lib - since the "types" is not set, tsc decided to recompile this code (with errors).
This PR fixes that.


```
$ tsc
node_modules/find-free-ports/index.ts:16:10 - error TS6133: 'clamp' is declared but its value is never read.

16 function clamp(value: number, min: number, max: number): number {
            ~~~~~


Found 1 error in node_modules/find-free-ports/index.ts:16

error Command failed with exit code 2.
```